### PR TITLE
Separate crew and enemy collision layers

### DIFF
--- a/Character/NPC/CrewMember/CrewMember.tscn
+++ b/Character/NPC/CrewMember/CrewMember.tscn
@@ -15,6 +15,8 @@ radius = 30.0
 
 [node name="CrewMember" instance=ExtResource("1_bh1s7")]
 z_index = 2
+collision_layer = 1
+collision_mask = 0
 script = ExtResource("2_oe6pe")
 npc_name = ""
 fight_side_right = false
@@ -39,6 +41,7 @@ position = Vector2(0.5, -1.5)
 
 [node name="MeleeRange" type="Area2D" parent="." index="4"]
 position = Vector2(0, -10)
+collision_mask = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="MeleeRange" index="0"]
 shape = SubResource("CircleShape2D_j5rlx")

--- a/Character/NPC/Enemy/Enemy.tscn
+++ b/Character/NPC/Enemy/Enemy.tscn
@@ -14,6 +14,8 @@ shader_parameter/hurt_color = Color(0.678, 0.196, 0.196, 0.6)
 radius = 30.0
 
 [node name="Enemy" instance=ExtResource("1_8o7wt")]
+collision_layer = 2
+collision_mask = 0
 script = ExtResource("2_0ie86")
 
 [node name="Appearance" parent="." index="0"]
@@ -28,6 +30,7 @@ position = Vector2(0.5, -1.5)
 
 [node name="MeleeRange" type="Area2D" parent="." index="4"]
 position = Vector2(0.5, -10)
+collision_mask = 1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="MeleeRange" index="0"]
 shape = SubResource("CircleShape2D_t3tbr")


### PR DESCRIPTION
## Summary
- isolate crew from enemy physics by assigning separate collision layers
- keep melee range detection cross-layer between crew and enemies

## Testing
- `godot3-server --path . --headless --quit` *(fails: Can't open project at '/workspace/Plunder/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine. Expected config version: 4.)*

------
https://chatgpt.com/codex/tasks/task_e_6892e7bf6ae8832bb9be4eae58226f9c